### PR TITLE
Fix a jQuery 3 incompatibility

### DIFF
--- a/src/jquery.validation.js
+++ b/src/jquery.validation.js
@@ -1814,7 +1814,7 @@
             var input;
             for (var i = 0; i < inputName.length; i++) {
 
-                input = $(node.selector).find('[name="' + inputName[i] + '"]');
+                input = node.find('[name="' + inputName[i] + '"]');
                 if (!input[0]) {
 
                     // {debug}


### PR DESCRIPTION
The selector property was dropped from jQuery 3 (see:
https://api.jquery.com/selector/).

In this instance (the removeError method), there is no need
for it in the first place. Instead, we can just use the
jQuery object provided (node).